### PR TITLE
[stylelint-root-colors] Consideration of multiple selectors separated by commas

### DIFF
--- a/packages/root-colors/README.md
+++ b/packages/root-colors/README.md
@@ -15,8 +15,7 @@ The root element is `:root { }` or `html { }`.
   color: #000;
 }
 
-/* 🆖 Do not specify only either `color` or `background-color` in the root element */
-:root {
+html, .foo {
   background-color: #fff;
 }
 

--- a/packages/root-colors/src/index.test.ts
+++ b/packages/root-colors/src/index.test.ts
@@ -28,6 +28,9 @@ testRule({
 		{
 			code: '.foo { color: #000 }',
 		},
+		{
+			code: 'html, :root, .foo {}',
+		},
 	],
 
 	reject: [
@@ -78,6 +81,14 @@ testRule({
 			column: 1,
 			endLine: 1,
 			endColumn: 6,
+		},
+		{
+			code: 'html, :root, .foo { background-color: #000 }',
+			message: messages.rejected('html, :root, .foo'),
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 18,
 		},
 	],
 });
@@ -131,6 +142,14 @@ testRule({
 			column: 1,
 			endLine: 1,
 			endColumn: 6,
+		},
+		{
+			code: '.root, .foo { background-color: #000 }',
+			message: messages.rejected('.root, .foo'),
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 12,
 		},
 	],
 });
@@ -217,6 +236,14 @@ testRule({
 			column: 1,
 			endLine: 1,
 			endColumn: 15,
+		},
+		{
+			code: '[element=root], [element=foo] { background-color: #000 }',
+			message: messages.rejected('[element=root], [element=foo]'),
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 30,
 		},
 	],
 });

--- a/packages/root-colors/src/index.ts
+++ b/packages/root-colors/src/index.ts
@@ -43,9 +43,9 @@ const ruleFunction: stylelint.Rule = (primary, secondaryOptions?) => (root, resu
 	}
 
 	root.walkRules((ruleNode) => {
-		const { selector } = ruleNode;
+		const { selector, selectors } = ruleNode;
 
-		if (!rootSelectors.includes(selector)) {
+		if (!selectors.some((selectorPart) => rootSelectors.includes(selectorPart))) {
 			return;
 		}
 


### PR DESCRIPTION
## Current behavior

- `html { color: #000 }` → Error
- `html, .foo { color: #000 }` → No error

## Corrected behavior

- `html, .foo { color: #000 }` → Error
